### PR TITLE
nick: Introduce `ChalFirebaseAuth`

### DIFF
--- a/code/app/src/main/java/com/nicholasrutherford/chal/dagger/modules/ActivityBuilderModule.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/dagger/modules/ActivityBuilderModule.kt
@@ -11,6 +11,7 @@ abstract class ActivityBuildersModule {
         modules = [
             AdapterModule::class,
             FragmentBuildersModule::class,
+            FirebaseHelperModule::class,
             JsonAssetReaderImplModule::class,
             NavigationImplModule::class,
             SharedPreferenceModule::class,

--- a/code/app/src/main/java/com/nicholasrutherford/chal/dagger/modules/FirebaseHelperModule.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/dagger/modules/FirebaseHelperModule.kt
@@ -1,0 +1,12 @@
+package com.nicholasrutherford.chal.dagger.modules
+
+import com.nicholasrutherford.chal.firebasehelper.ChalFirebaseAuthImpl
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+
+@Module
+abstract class FirebaseHelperModule {
+
+    @ContributesAndroidInjector
+    abstract fun contributeChalFirebaseAuth(): ChalFirebaseAuthImpl
+}

--- a/code/app/src/main/java/com/nicholasrutherford/chal/firebasehelper/ChalFirebaseAuth.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/firebasehelper/ChalFirebaseAuth.kt
@@ -1,0 +1,8 @@
+package com.nicholasrutherford.chal.firebasehelper
+
+import com.nicholasrutherford.chal.firebase.ChalFirebase
+
+interface ChalFirebaseAuth : ChalFirebase {
+    var isLoggedIn: Boolean
+    var uid: String?
+}

--- a/code/app/src/main/java/com/nicholasrutherford/chal/firebasehelper/ChalFirebaseAuthImpl.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/firebasehelper/ChalFirebaseAuthImpl.kt
@@ -1,0 +1,13 @@
+package com.nicholasrutherford.chal.firebasehelper
+
+import com.google.firebase.auth.FirebaseAuth
+import javax.inject.Inject
+
+class ChalFirebaseAuthImpl @Inject constructor() : ChalFirebaseAuth {
+
+    val firebaseAuth = FirebaseAuth.getInstance()
+
+    override var isLoggedIn: Boolean = firebaseAuth.currentUser != null
+
+    override var uid: String? = firebaseAuth.uid
+}

--- a/code/app/src/main/java/com/nicholasrutherford/chal/splashredesign/SplashRedesignViewModel.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/splashredesign/SplashRedesignViewModel.kt
@@ -1,17 +1,16 @@
 package com.nicholasrutherford.chal.splashredesign
 
-import android.app.Application
 import android.os.Handler
 import androidx.lifecycle.ViewModel
-import com.google.firebase.auth.FirebaseAuth
 import com.nicholasrutherford.chal.R
+import com.nicholasrutherford.chal.firebasehelper.ChalFirebaseAuthImpl
 import com.nicholasrutherford.chal.navigationimpl.splash.SplashRedesignNavigationImpl
 import javax.inject.Inject
 
 class SplashRedesignViewModel @Inject constructor(
-    private val application: Application,
+    private val firebaseAuth: ChalFirebaseAuthImpl,
     private val navigation: SplashRedesignNavigationImpl
-    ) : ViewModel() {
+) : ViewModel() {
 
     var viewState = SplashRedesignViewStateImpl()
 
@@ -19,7 +18,7 @@ class SplashRedesignViewModel @Inject constructor(
         val handler = Handler()
         handler.postDelayed(
             {
-                if (FirebaseAuth.getInstance().currentUser == null) {
+                if (!firebaseAuth.isLoggedIn) {
                     navigation.showlogin()
                 } else {
                     navigation.showHome()


### PR DESCRIPTION
### Jira
N/A 

### Issues
- When we use `FirebaseAuth` in the app, we always have to init and pull out override variables or methods we need from it. We could instead create a implementation of that class, that can get used all over the app. This allows us to only implement it everywhere when it gets injected. 

### Proposed Changes
- Introduce `ChalFirebaseAuth`. 

### TO-DO
- introduce more of these helper classes. 
