### PR TITLE
introduce main activity helper

### DIFF
--- a/code/app/src/main/java/com/nicholasrutherford/chal/dagger/modules/HelperModule.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/dagger/modules/HelperModule.kt
@@ -1,0 +1,12 @@
+package com.nicholasrutherford.chal.dagger.modules
+
+import com.nicholasrutherford.chal.main.helper.MainActivityHelperImpl
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+
+@Module
+abstract class HelperModule {
+
+    @ContributesAndroidInjector
+    abstract fun contributeMainActivityHelper(): MainActivityHelperImpl
+}

--- a/code/app/src/main/java/com/nicholasrutherford/chal/main/MainViewModel.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/main/MainViewModel.kt
@@ -16,11 +16,13 @@ import com.nicholasrutherford.chal.helpers.testfairy.ChalTestFairyImpl
 import com.nicholasrutherford.chal.navigationimpl.main.MainNavigationImpl
 import javax.inject.Inject
 
-class MainViewModel @Inject constructor(private val application: Application, mainActivity: MainActivity) : ViewModel() {
+class MainViewModel @Inject constructor(
+    private val application: Application,
+    private val navigation: MainNavigationImpl
+) : ViewModel() {
 
     val viewState = MainViewStateImpl()
 
-    private val navigation = MainNavigationImpl(application, mainActivity)
     val testFairy = ChalTestFairyImpl(application)
 
     var selectedPhotoUri: Uri? = null

--- a/code/app/src/main/java/com/nicholasrutherford/chal/main/helper /MainActivityHelper.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/main/helper /MainActivityHelper.kt
@@ -1,0 +1,8 @@
+package com.nicholasrutherford.chal.main.helper
+
+import com.nicholasrutherford.chal.Screens
+
+interface MainActivityHelper {
+    fun updateCurrentScreen(currentScreen: Screens)
+    fun updateBottomNavigationVisibility(isVisible: Boolean)
+}

--- a/code/app/src/main/java/com/nicholasrutherford/chal/main/helper /MainActivityHelperImpl.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/main/helper /MainActivityHelperImpl.kt
@@ -1,0 +1,18 @@
+package com.nicholasrutherford.chal.main.helper
+
+import com.nicholasrutherford.chal.Screens
+import com.nicholasrutherford.chal.helpers.visibleOrGone
+import com.nicholasrutherford.chal.main.MainActivity
+import kotlinx.android.synthetic.main.activity_main.*
+import javax.inject.Inject
+
+class MainActivityHelperImpl @Inject constructor(private val mainActivity: MainActivity) : MainActivityHelper {
+
+    override fun updateCurrentScreen(currentScreen: Screens) {
+        mainActivity.viewModel.updateCurrentScreen(currentScreen)
+    }
+
+    override fun updateBottomNavigationVisibility(isVisible: Boolean) {
+        mainActivity.bvNavigation.visibleOrGone = isVisible
+    }
+}

--- a/code/app/src/main/java/com/nicholasrutherford/chal/more/MoreViewModel.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/more/MoreViewModel.kt
@@ -26,14 +26,16 @@ import javax.inject.Inject
 const val MILLIS_IN_FUTURE = 3000
 const val COUNT_DOWN_INTERVAL = 100
 
-class MoreViewModel @Inject constructor(private val application: Application,
-    mainActivity: MainActivity) : ViewModel() {
+class MoreViewModel @Inject constructor(
+    private val application: Application,
+    private val navigation: MoreNavigationImpl,
+    mainActivity: MainActivity
+) : ViewModel() {
 
     private val ref = FirebaseDatabase.getInstance().getReference(USERS)
     private val uid = FirebaseAuth.getInstance().uid ?: ""
 
     val viewState = MoreViewStateImpl()
-    val navigation = MoreNavigationImpl(application, mainActivity)
 
     private val readProfileDetailsFirebase = ReadAccountFirebase(application.applicationContext)
 

--- a/code/app/src/main/java/com/nicholasrutherford/chal/navigationimpl/main/MainNavigationImpl.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/navigationimpl/main/MainNavigationImpl.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import com.nicholasrutherford.chal.challengesredesign.challenges.ChallengesRedesignFragment
 import com.nicholasrutherford.chal.main.MainActivity
 import com.nicholasrutherford.chal.main.MainNavigation
+import com.nicholasrutherford.chal.main.helper.MainActivityHelperImpl
 import com.nicholasrutherford.chal.more.MoreFragment
 import com.nicholasrutherford.chal.navigationimpl.challengeredesign.container
 import com.nicholasrutherford.chal.newsfeed.NewsFeedFragment
@@ -14,7 +15,11 @@ import com.nicholasrutherford.chal.progressupload.ProgressUploadParams
 import com.nicholasrutherford.chal.splashredesign.SplashRedesignFragment
 import javax.inject.Inject
 
-class MainNavigationImpl @Inject constructor(private val application: Application, private val mainActivity: MainActivity) : MainNavigation {
+class MainNavigationImpl @Inject constructor(
+    private val application: Application,
+    private val mainActivityHelper: MainActivityHelperImpl,
+    private val mainActivity: MainActivity
+    ) : MainNavigation {
 
     override fun finish() = mainActivity.finish()
 
@@ -70,8 +75,8 @@ class MainNavigationImpl @Inject constructor(private val application: Applicatio
         mainActivity.supportFragmentManager.beginTransaction()
             .replace(
                 container,
-                ProgressUploadFragment(application, params),
-                ProgressUploadFragment(application, params)::javaClass.name
+                ProgressUploadFragment(application, mainActivityHelper, params),
+                ProgressUploadFragment(application, mainActivityHelper, params)::javaClass.name
             )
             .addToBackStack(null)
             .commit()

--- a/code/app/src/main/java/com/nicholasrutherford/chal/navigationimpl/more/MoreNavigationImpl.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/navigationimpl/more/MoreNavigationImpl.kt
@@ -11,6 +11,7 @@ import com.nicholasrutherford.chal.R
 import com.nicholasrutherford.chal.account.login.LoginActivity
 import com.nicholasrutherford.chal.bugreport.BugReportFragment
 import com.nicholasrutherford.chal.helpers.visibleOrGone
+import com.nicholasrutherford.chal.main.helper.MainActivityHelperImpl
 import com.nicholasrutherford.chal.more.MoreNavigation
 import com.nicholasrutherford.chal.navigationimpl.challengeredesign.container
 import com.nicholasrutherford.chal.profile.profiles.MyProfileFragment
@@ -18,7 +19,11 @@ import com.nicholasrutherford.chal.progressupload.ProgressUploadFragment
 import com.nicholasrutherford.chal.progressupload.ProgressUploadParams
 import javax.inject.Inject
 
-class MoreNavigationImpl @Inject constructor(private val application: Application, private val mainActivity: MainActivity) : MoreNavigation {
+class MoreNavigationImpl @Inject constructor(
+    private val application: Application,
+    private val mainActivityHelper: MainActivityHelperImpl,
+    private val mainActivity: MainActivity
+    ) : MoreNavigation {
 
     private var flowerLoadingDialog: ACProgressFlower? = null
 
@@ -80,8 +85,8 @@ class MoreNavigationImpl @Inject constructor(private val application: Applicatio
         mainActivity.supportFragmentManager.beginTransaction()
             .replace(
                 container,
-                ProgressUploadFragment(application, params),
-                ProgressUploadFragment(application, params)::javaClass.name
+                ProgressUploadFragment(application, mainActivityHelper, params),
+                ProgressUploadFragment(application, mainActivityHelper, params)::javaClass.name
             )
             .addToBackStack("")
             .commit()

--- a/code/app/src/main/java/com/nicholasrutherford/chal/navigationimpl/newsfeed/NewsFeedNavigationImpl.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/navigationimpl/newsfeed/NewsFeedNavigationImpl.kt
@@ -8,6 +8,7 @@ import cc.cloudist.acplibrary.ACProgressConstant
 import cc.cloudist.acplibrary.ACProgressFlower
 import com.nicholasrutherford.chal.main.MainActivity
 import com.nicholasrutherford.chal.R
+import com.nicholasrutherford.chal.main.helper.MainActivityHelperImpl
 import com.nicholasrutherford.chal.navigationimpl.challengeredesign.container
 import com.nicholasrutherford.chal.newsfeed.NewsFeedNavigation
 import com.nicholasrutherford.chal.peoplelist.PeopleListFragment
@@ -15,7 +16,11 @@ import com.nicholasrutherford.chal.progressupload.ProgressUploadFragment
 import com.nicholasrutherford.chal.progressupload.ProgressUploadParams
 import javax.inject.Inject
 
-class NewsFeedNavigationImpl @Inject constructor(private val application: Application, private val mainActivity: MainActivity) : NewsFeedNavigation {
+class NewsFeedNavigationImpl @Inject constructor(
+    private val application: Application,
+    private val mainActivityHelper: MainActivityHelperImpl,
+    private val mainActivity: MainActivity
+    ) : NewsFeedNavigation {
 
     private var flowerLoadingDialog: ACProgressFlower? = null
 
@@ -78,8 +83,8 @@ class NewsFeedNavigationImpl @Inject constructor(private val application: Applic
         mainActivity.supportFragmentManager.beginTransaction()
             .replace(
                 container,
-                ProgressUploadFragment(application, params),
-                ProgressUploadFragment(application, params)::javaClass.name
+                ProgressUploadFragment(application, mainActivityHelper, params),
+                ProgressUploadFragment(application, mainActivityHelper, params)::javaClass.name
             )
             .addToBackStack("")
             .commit()

--- a/code/app/src/main/java/com/nicholasrutherford/chal/newsfeed/NewsFeedViewModel.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/newsfeed/NewsFeedViewModel.kt
@@ -31,7 +31,11 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-class NewsFeedViewModel @Inject constructor(private val application: Application, mainActivity: MainActivity) : ViewModel() {
+class NewsFeedViewModel @Inject constructor(
+    private val application: Application,
+    private val navigation: NewsFeedNavigationImpl,
+    mainActivity: MainActivity
+) : ViewModel() {
 
     private val readProfileDetailsFirebase = ReadAccountFirebase(application.applicationContext)
 
@@ -70,8 +74,6 @@ class NewsFeedViewModel @Inject constructor(private val application: Application
 
     private val clearFirebaseSharedPref = ClearFirebaseSharedPref(application)
     private val writeAccountInfoImpl = WriteAccountInfoImpl()
-
-    val navigation = NewsFeedNavigationImpl(application, mainActivity)
 
     init {
         mAuth = FirebaseAuth.getInstance()

--- a/code/app/src/main/java/com/nicholasrutherford/chal/progressupload/ProgressUploadFragment.kt
+++ b/code/app/src/main/java/com/nicholasrutherford/chal/progressupload/ProgressUploadFragment.kt
@@ -16,15 +16,18 @@ import com.nicholasrutherford.chal.ext.activitys.ProgressUploadExt
 import com.nicholasrutherford.chal.helpers.Typeface
 import com.nicholasrutherford.chal.helpers.visibleOrGone
 import com.nicholasrutherford.chal.main.MainActivity
+import com.nicholasrutherford.chal.main.helper.MainActivityHelperImpl
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-class ProgressUploadFragment @Inject constructor(private val application: Application, private val params: ProgressUploadParams) :
-    DaggerFragment(),
-    ProgressUploadExt {
+class ProgressUploadFragment @Inject constructor(
+    private val application: Application,
+    private val mainActivityHelper: MainActivityHelperImpl,
+    private val params: ProgressUploadParams
+    ) : DaggerFragment(), ProgressUploadExt {
 
         @Inject
         lateinit var viewModelFactory: ViewModelProvider.Factory
@@ -41,9 +44,8 @@ class ProgressUploadFragment @Inject constructor(private val application: Applic
     private var selectedPhotoUri: Uri? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        val mainActivity: MainActivity = (activity as MainActivity)
-        mainActivity.viewModel.updateCurrentScreen(Screens.UPLOAD_PROGRESS)
-        mainActivity.bvNavigation.visibleOrGone = false
+        mainActivityHelper.updateCurrentScreen(currentScreen = Screens.UPLOAD_PROGRESS)
+        mainActivityHelper.updateBottomNavigationVisibility(isVisible = false)
 
         val bind = FragmentProgressUploadBinding.inflate(layoutInflater)
 


### PR DESCRIPTION
### Jira
N/A 

### Issues
- We currently have to override the `MainActivity` class in a lot of our fragments, to hide the bottom navigation or to update what fragment we are on. Its tiresome to do the same functionality, in each and every fragment. 

### Proposed Changes
- Introduce `MainActivityHelper` that will allow us to use those override methods in the fragments, by just injecting the `impl`. 
- Create a new dagger `Helper` module, that will be used for more future helper modules. 