### PR TITLE
nick: `RemoveSharedPreferences` functionality for all existing shared preferences

### DIFF
--- a/code/account/create-account/src/main/java/com/nicholasrutherford/chal/create/account/uploadphoto/UploadPhotoViewModel.kt
+++ b/code/account/create-account/src/main/java/com/nicholasrutherford/chal/create/account/uploadphoto/UploadPhotoViewModel.kt
@@ -69,8 +69,7 @@ class UploadPhotoViewModel @ViewModelInject constructor(
                 profileUri = Uri.parse(profilePictureDirectory)
                 viewState.imageTakeAPhotoBitmap = getCapturedImage(profileUri as Uri)
 
-                removeSharedPreference.removeProfilePictureDirectorySharedPreference(
-                    PROFILE_PICTURE_DIRECTORY_PREFERENCE)
+                removeSharedPreference.removeProfilePictureDirectorySharedPreference()
                 setViewStateAsUpdated()
             }
             updateIsPhotoReadyToBeUpdated(false)

--- a/code/buildSrc/build/source-roots/buildSrc/source-roots.txt
+++ b/code/buildSrc/build/source-roots/buildSrc/source-roots.txt
@@ -1,0 +1,8 @@
+src/main/resources
+src/main/java
+src/main/groovy
+src/main/kotlin
+src/test/resources
+src/test/java
+src/test/groovy
+src/test/kotlin

--- a/code/helper/constants/src/main/java/com/nicholasrutherford/chal/helper/constants/Constants.kt
+++ b/code/helper/constants/src/main/java/com/nicholasrutherford/chal/helper/constants/Constants.kt
@@ -13,6 +13,9 @@ const val LOADING_DELAY = 1000
 // hide keyboard flag 0
 const val KEYBOARD_FLAGS = 0
 
+// we can't set shared int shared preferences to null, so set it to 11 as a default value
+const val STOCK_INT_PREFERENCE = 11
+
 // constants for shared preference
 const val CHAL_PREFERENCES = "CHAL_PREFERENCES"
 const val PROFILE_PICTURE_DIRECTORY_PREFERENCE = "PROFILE_PICTURE_DIRECTORY_PREFERENCE"

--- a/code/shared-preference/fetch/build.gradle.kts
+++ b/code/shared-preference/fetch/build.gradle.kts
@@ -15,9 +15,11 @@ android {
 }
 
 dependencies {
-    implementation(Dependencies.Libs.UI.AcProgress)
+    api(project(path = ":helper:constants"))
 
+    implementation(Dependencies.Libs.UI.AcProgress)
     implementation(Dependencies.Libs.Hilt.DaggerHiltAndroid)
+    
     kapt(Dependencies.Libs.Hilt.DaggerHiltAndroidCompiler)
     kapt(Dependencies.Libs.Hilt.hiltCompiler)
 }

--- a/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreferenceImpl.kt
+++ b/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreferenceImpl.kt
@@ -2,13 +2,14 @@ package com.nicholasrutherford.chal.shared.preference.fetch
 
 import android.app.Application
 import android.content.Context
+import com.nicholasrutherford.chal.helper.constants.CHAL_PREFERENCES
 import javax.inject.Inject
 
 class FetchSharedPreferenceImpl @Inject constructor(
     application: Application
 ): FetchSharedPreference {
 
-    private val sharedPreference = application.getSharedPreferences("chal-preferences", Context.MODE_PRIVATE)
+    private val sharedPreference = application.getSharedPreferences(CHAL_PREFERENCES, Context.MODE_PRIVATE)
 
     override fun fetchProfilePictureDirectorySharedPreference(preferenceName: String): String? {
         val profilePictureDirectory = sharedPreference.getString(preferenceName, null)

--- a/code/shared-preference/remove/build.gradle.kts
+++ b/code/shared-preference/remove/build.gradle.kts
@@ -15,9 +15,11 @@ android {
 }
 
 dependencies {
-    implementation(Dependencies.Libs.UI.AcProgress)
+    api(project(path = ":helper:constants"))
 
+    implementation(Dependencies.Libs.UI.AcProgress)
     implementation(Dependencies.Libs.Hilt.DaggerHiltAndroid)
+    
     kapt(Dependencies.Libs.Hilt.DaggerHiltAndroidCompiler)
     kapt(Dependencies.Libs.Hilt.hiltCompiler)
 }

--- a/code/shared-preference/remove/src/main/java/com/nicholasrutherford/chal/shared/preference/remove/RemoveSharedPreference.kt
+++ b/code/shared-preference/remove/src/main/java/com/nicholasrutherford/chal/shared/preference/remove/RemoveSharedPreference.kt
@@ -1,14 +1,21 @@
 package com.nicholasrutherford.chal.shared.preference.remove
 
 interface RemoveSharedPreference {
+    // firebase
     fun removeProfilePictureDirectorySharedPreference()
+
+    // account shared preferences
     fun removeAgeSharedPreference()
+    fun removeBioSharedPreference()
     fun removeEmailSharedPreference()
     fun removeLastNameSharedPreference()
     fun removeFirstNameSharedPreference()
     fun removeIdSharedPreference()
     fun removeProfilePictureSharedPreference()
     fun removeUsernameSharedPreference()
+
+    // challenge banner shared preferences
+    fun removeBannerTypeSharedPreference()
     fun removeChallengeBannerTypeTitleSharedPreference()
     fun removeChallengeBannerTypeDescSharedPreference()
     fun removeChallengeBannerTypeIsVisible()

--- a/code/shared-preference/remove/src/main/java/com/nicholasrutherford/chal/shared/preference/remove/RemoveSharedPreference.kt
+++ b/code/shared-preference/remove/src/main/java/com/nicholasrutherford/chal/shared/preference/remove/RemoveSharedPreference.kt
@@ -1,6 +1,17 @@
 package com.nicholasrutherford.chal.shared.preference.remove
 
 interface RemoveSharedPreference {
-    fun removeProfilePictureDirectorySharedPreference(preferenceName: String)
+    fun removeProfilePictureDirectorySharedPreference()
+    fun removeAgeSharedPreference()
+    fun removeEmailSharedPreference()
+    fun removeLastNameSharedPreference()
+    fun removeFirstNameSharedPreference()
+    fun removeIdSharedPreference()
+    fun removeProfilePictureSharedPreference()
+    fun removeUsernameSharedPreference()
+    fun removeChallengeBannerTypeTitleSharedPreference()
+    fun removeChallengeBannerTypeDescSharedPreference()
+    fun removeChallengeBannerTypeIsVisible()
+    fun removeChallengeBannerTypeIsCloseable()
     fun removeAllSharedPreferences()
 }

--- a/code/shared-preference/remove/src/main/java/com/nicholasrutherford/chal/shared/preference/remove/RemoveSharedPreferenceImpl.kt
+++ b/code/shared-preference/remove/src/main/java/com/nicholasrutherford/chal/shared/preference/remove/RemoveSharedPreferenceImpl.kt
@@ -2,20 +2,82 @@ package com.nicholasrutherford.chal.shared.preference.remove
 
 import android.app.Application
 import android.content.Context
-import com.nicholasrutherford.chal.helper.constants.PROFILE_PICTURE_DIRECTORY_PREFERENCE
+import com.nicholasrutherford.chal.helper.constants.*
 import javax.inject.Inject
 
 class RemoveSharedPreferenceImpl @Inject constructor(
     application: Application
 ) : RemoveSharedPreference {
 
-    private val sharedPreference = application.getSharedPreferences("chal-preferences", Context.MODE_PRIVATE)
+    private val sharedPreference = application.getSharedPreferences(CHAL_PREFERENCES, Context.MODE_PRIVATE)
     private val editor = sharedPreference.edit()
 
-    override fun removeProfilePictureDirectorySharedPreference() {
-        if (!sharedPreference.getString(PROFILE_PICTURE_DIRECTORY_PREFERENCE, null).isNullOrEmpty()) {
-            editor.remove(PROFILE_PICTURE_DIRECTORY_PREFERENCE).apply()
+    private fun checkAndRemoveSharedPreferenceString(sharedPreferenceName: String) {
+        if (!sharedPreference.getString(sharedPreferenceName, null).isNullOrEmpty()) {
+            editor.remove(sharedPreferenceName).apply()
         }
+    }
+
+    private fun checkAndRemovePreferenceInt(sharedPreferenceName: String) {
+        if (sharedPreference.getInt(sharedPreferenceName, STOCK_INT_PREFERENCE) != STOCK_INT_PREFERENCE) {
+            editor.remove(sharedPreferenceName).apply()
+        }
+    }
+
+    override fun removeProfilePictureDirectorySharedPreference() {
+        checkAndRemoveSharedPreferenceString(PROFILE_PICTURE_DIRECTORY_PREFERENCE)
+    }
+
+    override fun removeAgeSharedPreference() {
+        checkAndRemovePreferenceInt(AGE_PREFERENCE)
+    }
+
+    override fun removeBioSharedPreference() {
+        checkAndRemoveSharedPreferenceString(BIO_PREFERENCE)
+    }
+
+    override fun removeEmailSharedPreference() {
+        checkAndRemoveSharedPreferenceString(EMAIL_PREFERENCE)
+    }
+
+    override fun removeLastNameSharedPreference() {
+        checkAndRemoveSharedPreferenceString(LAST_NAME_PREFERENCE)
+    }
+
+    override fun removeFirstNameSharedPreference() {
+        checkAndRemoveSharedPreferenceString(FIRST_NAME_PREFERENCE)
+    }
+
+    override fun removeIdSharedPreference() {
+        checkAndRemovePreferenceInt(ID_PREFERENCE)
+    }
+
+    override fun removeProfilePictureSharedPreference() {
+        checkAndRemoveSharedPreferenceString(PROFILE_PICTURE_PREFERENCE)
+    }
+
+    override fun removeUsernameSharedPreference() {
+        checkAndRemoveSharedPreferenceString(USERNAME_PREFERENCE)
+    }
+
+    override fun removeBannerTypeSharedPreference() {
+        checkAndRemovePreferenceInt(BANNER_TYPE_PREFERENCE)
+    }
+
+    override fun removeChallengeBannerTypeTitleSharedPreference() {
+        checkAndRemoveSharedPreferenceString(BANNER_TYPE_TITLE)
+    }
+
+    override fun removeChallengeBannerTypeDescSharedPreference() {
+        checkAndRemoveSharedPreferenceString(BANNER_TYPE_PREFERENCE)
+    }
+
+    override fun removeChallengeBannerTypeIsVisible() {
+        editor.remove(BANNER_TYPE_IS_VISIBLE).apply()
+    }
+
+    override fun removeChallengeBannerTypeIsCloseable() {
+        editor.remove(BANNER_TYPE_IS_CLOSEABLE).apply()
     }
 
     override fun removeAllSharedPreferences() {

--- a/code/shared-preference/remove/src/main/java/com/nicholasrutherford/chal/shared/preference/remove/RemoveSharedPreferenceImpl.kt
+++ b/code/shared-preference/remove/src/main/java/com/nicholasrutherford/chal/shared/preference/remove/RemoveSharedPreferenceImpl.kt
@@ -2,6 +2,7 @@ package com.nicholasrutherford.chal.shared.preference.remove
 
 import android.app.Application
 import android.content.Context
+import com.nicholasrutherford.chal.helper.constants.PROFILE_PICTURE_DIRECTORY_PREFERENCE
 import javax.inject.Inject
 
 class RemoveSharedPreferenceImpl @Inject constructor(
@@ -11,9 +12,9 @@ class RemoveSharedPreferenceImpl @Inject constructor(
     private val sharedPreference = application.getSharedPreferences("chal-preferences", Context.MODE_PRIVATE)
     private val editor = sharedPreference.edit()
 
-    override fun removeProfilePictureDirectorySharedPreference(preferenceName: String) {
-        if (!sharedPreference.getString(preferenceName, null).isNullOrEmpty()) {
-            editor.remove(preferenceName).apply()
+    override fun removeProfilePictureDirectorySharedPreference() {
+        if (!sharedPreference.getString(PROFILE_PICTURE_DIRECTORY_PREFERENCE, null).isNullOrEmpty()) {
+            editor.remove(PROFILE_PICTURE_DIRECTORY_PREFERENCE).apply()
         }
     }
 


### PR DESCRIPTION
### Trello
https://trello.com/c/CRRkCT41/27-removesharedpreferences-functionality-for-all-existing-shared-preferences

### Issues
- We need a way to remove shared preferences once were done with them. 

### Proposed Changes
- Add functionality to the `RemoveSharedPreferencesImpl` that states, if we have a shared preference and it exists go ahead and remove them(for boolean we can set them to false even if they don't exist, since its either true or false). 

### TO-DO
- Add functionality to the `FetchSharedPreferenceImpl` that allows us to grab values from our created shared preferences. 

### Additional Info
- In the future I see this being branched out a bit, but this works fine for now(it does its job). 

### Screenshots
- Not applicable 
