### PR TITLE
nick: `FetchSharedPreference` functionality for all existing shared preferences

### DIFF
--- a/code/account/create-account/src/main/java/com/nicholasrutherford/chal/create/account/uploadphoto/UploadPhotoViewModel.kt
+++ b/code/account/create-account/src/main/java/com/nicholasrutherford/chal/create/account/uploadphoto/UploadPhotoViewModel.kt
@@ -60,8 +60,7 @@ class UploadPhotoViewModel @ViewModelInject constructor(
     fun onImageUpdate() {
         if (isPhotoReadyToBeUpdated) {
             val profilePictureDirectory =
-                fetchSharedPreference.fetchProfilePictureDirectorySharedPreference(
-                    PROFILE_PICTURE_DIRECTORY_PREFERENCE)
+                fetchSharedPreference.fetchProfilePictureDirectorySharedPreference()
 
             if (profilePictureDirectory.isNullOrEmpty()) {
                 viewState.imageTakeAPhotoBitmap = null

--- a/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreference.kt
+++ b/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreference.kt
@@ -1,5 +1,23 @@
 package com.nicholasrutherford.chal.shared.preference.fetch
 
 interface FetchSharedPreference {
+    // firebase
     fun fetchProfilePictureDirectorySharedPreference(preferenceName: String): String?
+
+    // account shared preferences
+    fun fetchAgeSharedPreference(): Int?
+    fun fetchBioSharedPreference(): String?
+    fun fetchEmailSharedPreference(): String?
+    fun fetchLastNameSharedPreference(): String?
+    fun fetchFirstNameSharedPreference(): String?
+    fun fetchIdSharedPreference(): Int?
+    fun fetchProfilePictureSharedPreference(): String?
+    fun fetchUsernameSharedPreference(): String?
+
+    // challenge banner shared preferences
+    fun fetchBannerTypeSharedPreference(): Int?
+    fun fetchChallengeBannerTypeTitleSharedPreference(): String?
+    fun fetchChallengeBannerTypeDescription(): String?
+    fun fetchChallengeBannerTypeIsVisible(): Boolean
+    fun fetchChallengeBannerTypeIsCloseable(): Boolean
 }

--- a/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreference.kt
+++ b/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreference.kt
@@ -2,7 +2,7 @@ package com.nicholasrutherford.chal.shared.preference.fetch
 
 interface FetchSharedPreference {
     // firebase
-    fun fetchProfilePictureDirectorySharedPreference(preferenceName: String): String?
+    fun fetchProfilePictureDirectorySharedPreference(): String?
 
     // account shared preferences
     fun fetchAgeSharedPreference(): Int?

--- a/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreferenceImpl.kt
+++ b/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreferenceImpl.kt
@@ -23,13 +23,11 @@ class FetchSharedPreferenceImpl @Inject constructor(
         return sharedPreference.getBoolean(preferenceName, false)
     }
 
-    override fun fetchProfilePictureDirectorySharedPreference(preferenceName: String): String? {
-        val profilePictureDirectory = sharedPreference.getString(preferenceName, null)
-
-        if (profilePictureDirectory.isNullOrEmpty()) {
-            return  null
+    override fun fetchProfilePictureDirectorySharedPreference(): String? {
+        if (getPreferenceString(PROFILE_PICTURE_DIRECTORY_PREFERENCE).isNullOrEmpty()) {
+            return null
         } else {
-            return profilePictureDirectory
+            return getPreferenceString(PROFILE_PICTURE_DIRECTORY_PREFERENCE)
         }
     }
 

--- a/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreferenceImpl.kt
+++ b/code/shared-preference/fetch/src/main/java/com/nicholasrutherford/chal/shared/preference/fetch/FetchSharedPreferenceImpl.kt
@@ -2,7 +2,7 @@ package com.nicholasrutherford.chal.shared.preference.fetch
 
 import android.app.Application
 import android.content.Context
-import com.nicholasrutherford.chal.helper.constants.CHAL_PREFERENCES
+import com.nicholasrutherford.chal.helper.constants.*
 import javax.inject.Inject
 
 class FetchSharedPreferenceImpl @Inject constructor(
@@ -10,6 +10,18 @@ class FetchSharedPreferenceImpl @Inject constructor(
 ): FetchSharedPreference {
 
     private val sharedPreference = application.getSharedPreferences(CHAL_PREFERENCES, Context.MODE_PRIVATE)
+
+    private fun getPreferenceString(preferenceName: String): String? {
+        return sharedPreference.getString(preferenceName, null)
+    }
+
+    private fun getPreferenceInt(preferenceName: String): Int {
+        return sharedPreference.getInt(preferenceName, STOCK_INT_PREFERENCE)
+    }
+
+    private fun getPreferenceBoolean(preferenceName: String): Boolean {
+        return sharedPreference.getBoolean(preferenceName, false)
+    }
 
     override fun fetchProfilePictureDirectorySharedPreference(preferenceName: String): String? {
         val profilePictureDirectory = sharedPreference.getString(preferenceName, null)
@@ -19,5 +31,101 @@ class FetchSharedPreferenceImpl @Inject constructor(
         } else {
             return profilePictureDirectory
         }
+    }
+
+    override fun fetchAgeSharedPreference(): Int? {
+        if (getPreferenceInt(AGE_PREFERENCE) == STOCK_INT_PREFERENCE) {
+            return null
+        } else {
+            return getPreferenceInt(AGE_PREFERENCE)
+        }
+    }
+
+    override fun fetchBioSharedPreference(): String? {
+        if (getPreferenceString(BIO_PREFERENCE).isNullOrEmpty()) {
+            return null
+        } else {
+            return getPreferenceString(BIO_PREFERENCE)
+        }
+    }
+
+    override fun fetchEmailSharedPreference(): String? {
+        if (getPreferenceString(EMAIL_PREFERENCE).isNullOrEmpty()) {
+            return null
+        } else {
+            return getPreferenceString(EMAIL_PREFERENCE)
+        }
+    }
+
+    override fun fetchLastNameSharedPreference(): String? {
+        if (getPreferenceString(LAST_NAME_PREFERENCE).isNullOrEmpty()) {
+            return null
+        } else {
+            return getPreferenceString(LAST_NAME_PREFERENCE)
+        }
+    }
+
+    override fun fetchFirstNameSharedPreference(): String? {
+        if (getPreferenceString(FIRST_NAME_PREFERENCE).isNullOrEmpty()) {
+            return null
+        } else {
+            return getPreferenceString(FIRST_NAME_PREFERENCE)
+        }
+    }
+
+    override fun fetchIdSharedPreference(): Int? {
+        if (getPreferenceInt(ID_PREFERENCE) == STOCK_INT_PREFERENCE) {
+            return null
+        } else {
+            return getPreferenceInt(ID_PREFERENCE)
+        }
+    }
+
+    override fun fetchProfilePictureSharedPreference(): String? {
+        if (getPreferenceString(PROFILE_PICTURE_PREFERENCE).isNullOrEmpty()) {
+            return null
+        } else {
+            return getPreferenceString(PROFILE_PICTURE_PREFERENCE)
+        }
+    }
+
+    override fun fetchUsernameSharedPreference(): String? {
+        if (getPreferenceString(USERNAME_PREFERENCE).isNullOrEmpty()) {
+            return null
+        } else {
+            return getPreferenceString(USERNAME_PREFERENCE)
+        }
+    }
+
+    override fun fetchBannerTypeSharedPreference(): Int? {
+        if (getPreferenceInt(BANNER_TYPE_PREFERENCE) == STOCK_INT_PREFERENCE) {
+            return null
+        } else {
+            return getPreferenceInt(BANNER_TYPE_PREFERENCE)
+        }
+    }
+
+    override fun fetchChallengeBannerTypeTitleSharedPreference(): String? {
+        if (getPreferenceString(BANNER_TYPE_TITLE).isNullOrEmpty()) {
+            return null
+        } else {
+            return getPreferenceString(BANNER_TYPE_TITLE)
+        }
+    }
+
+    override fun fetchChallengeBannerTypeDescription(): String? {
+        if (getPreferenceString(BANNER_TYPE_DESCRIPTION).isNullOrEmpty()) {
+            return null
+        } else {
+            return getPreferenceString(BANNER_TYPE_DESCRIPTION)
+        }
+    }
+
+    override fun fetchChallengeBannerTypeIsVisible(): Boolean {
+        return getPreferenceBoolean(BANNER_TYPE_IS_VISIBLE)
+    }
+
+    override fun fetchChallengeBannerTypeIsCloseable(): Boolean {
+        return getPreferenceBoolean(BANNER_TYPE_IS_CLOSEABLE)
     }
 }


### PR DESCRIPTION
### Trello 
https://trello.com/c/5scYQouv/28-fetchsharedpreference-functionality-for-all-existing-shared-preferences

### Issues
- With all of our shared preferences, we need to add the ability to fetch those shared preferences only when there not null(for booleans we default them back to false, since booleans obv can't be null). 

### Proposed Changes
- Add fetch shared preferences functionality, in the implementation class. 

### TO-DO
- Image rotation fix. 

### Additional Info
- In the future, I do see this being split up into certain categories(but because this is so small this will work for now!)

### Screenshots
- Not applicable 
