### PR TITLE
nick: Navigate to news feed screen on load, if I am signed into my account

### DIFF
--- a/code/main/splash/src/main/java/com/nicholasrutherford/chal/main/splash/SplashViewModel.kt
+++ b/code/main/splash/src/main/java/com/nicholasrutherford/chal/main/splash/SplashViewModel.kt
@@ -22,7 +22,7 @@ class SplashViewModel @ViewModelInject constructor(
             if (!firebaseAuth.isLoggedIn) {
                 navigation.showlogin()
             } else {
-                navigation.showlogin()
+                navigation.showNewsFeed()
             }
         }, SPLASH_DELAYED.toLong())
     }


### PR DESCRIPTION
### Trello
https://trello.com/c/auiOE2Ar/30-navigate-to-news-feed-screen-on-load-if-i-am-signed-into-my-account

### Issues
- If I am a user who is logged in to a account on the app, and I got navigate back to the app; after the splash screen gets loaded it should take me to the news feed screen. It currently does not, and instead takes me to the login screen no matter what. 

### Proposed Changes
- As a existing user, who is logged in navigate me to the news feed screen to start my user flow. 

### TO-DO
- Some rework needs to be done for a helper function. 