### PR TITLE
nick: Give option for user to take a picture or pick image from gallery when uploading progress 

### DIFF
--- a/code/account/create-account/src/main/java/com/nicholasrutherford/chal/create/account/uploadphoto/UploadPhotoFragment.kt
+++ b/code/account/create-account/src/main/java/com/nicholasrutherford/chal/create/account/uploadphoto/UploadPhotoFragment.kt
@@ -52,17 +52,18 @@ class UploadPhotoFragment @Inject constructor(): BaseFragment<UploadPhotoFragmen
                 viewModel._shouldDismissProgress
             )
         }
-        collectAlertAsUpdated()
-    }
-
-    override fun collectAlertAsUpdated() {
         lifecycleScope.launch {
-            viewModel.shouldShowAlert.collect { isShouldShowAlert ->
-                if (isShouldShowAlert) {
-                    showOkAlert(title = viewModel.alertTitle, message = viewModel.alertMessage)
-                }
-                viewModel.setShouldShowAlertAsNotUpdated()
-            }
+            collectIsGalleryResult()
+        }
+        lifecycleScope.launch {
+            collectIsTakePictureResult()
+        }
+        lifecycleScope.launch {
+            collectShouldShowAlertResult(
+                this@UploadPhotoFragment.id,
+                viewModel.alert,
+                viewModel._alert
+            )
         }
     }
 
@@ -71,6 +72,8 @@ class UploadPhotoFragment @Inject constructor(): BaseFragment<UploadPhotoFragmen
         viewModel.onImageUpdate()
     }
 
+    override fun collectAlertAsUpdated() = Unit
+
     override fun updateTypefaces() {
         binding?.let { binding ->
             typeface.setTextViewHeaderBoldTypeface(binding.tvTakeAPictureOrChooseFromLibrary)
@@ -78,21 +81,14 @@ class UploadPhotoFragment @Inject constructor(): BaseFragment<UploadPhotoFragmen
                 application,
                 R.style.ToolbarTextAppearance
             )
-
-            typeface.setTextViewBodyBoldTypeface(binding.btnChooseFormLibrary)
             typeface.setTextViewBodyBoldTypeface(binding.btnContinueUpload)
         }
     }
 
     override fun onListener() {
         binding?.let { binding ->
-            binding.btnChooseFormLibrary.setOnClickListener {
-                viewModel.updateIsPhotoReadyToBeUpdated(true)
-                openGallery()
-            }
             binding.cvTakeAPhoto.setOnClickListener {
                 viewModel.updateIsPhotoReadyToBeUpdated(true)
-                openCamera()
             }
             binding.btnContinueUpload.setOnClickListener {
                 viewModel.onContinueClicked()
@@ -108,4 +104,5 @@ class UploadPhotoFragment @Inject constructor(): BaseFragment<UploadPhotoFragmen
             }
         }
     }
+
 }

--- a/code/account/create-account/src/main/java/com/nicholasrutherford/chal/create/account/uploadphoto/UploadPhotoViewModel.kt
+++ b/code/account/create-account/src/main/java/com/nicholasrutherford/chal/create/account/uploadphoto/UploadPhotoViewModel.kt
@@ -12,6 +12,7 @@ import com.nicholasrutherford.chal.Network
 import com.nicholasrutherford.chal.create.account.R
 import com.nicholasrutherford.chal.data.account.info.AccountInfo
 import com.nicholasrutherford.chal.data.account.info.ProfileInfo
+import com.nicholasrutherford.chal.data.elert.AlertType
 import com.nicholasrutherford.chal.firebase.auth.ChalFirebaseAuth
 import com.nicholasrutherford.chal.firebase.realtime.database.fetch.FetchFirebaseDatabase
 import com.nicholasrutherford.chal.firebase.storage.ChalFirebaseStorage
@@ -55,6 +56,12 @@ class UploadPhotoViewModel @ViewModelInject constructor(
 
     fun updateIsPhotoReadyToBeUpdated(isPhotoReadyToBeUpdated: Boolean) {
         this.isPhotoReadyToBeUpdated = isPhotoReadyToBeUpdated
+        setShouldSetAlertAsUpdated(
+            title = application.getString(R.string.uploading_image),
+            message = application.getString(R.string.how_would_you_like_to_upload_your_image),
+            type = AlertType.CAMERA_OR_GALLERY_ALERT,
+            shouldCloseAppAfterDone = false
+        )
     }
 
     fun onImageUpdate() {
@@ -71,7 +78,6 @@ class UploadPhotoViewModel @ViewModelInject constructor(
                 removeSharedPreference.removeProfilePictureDirectorySharedPreference()
                 setViewStateAsUpdated()
             }
-            updateIsPhotoReadyToBeUpdated(false)
         }
     }
 
@@ -97,10 +103,14 @@ class UploadPhotoViewModel @ViewModelInject constructor(
     }
 
     private fun showErrorState(desc: String) {
-        alertTitle = application.getString(R.string.error_cant_create_account)
-        alertMessage = desc
+        setShouldSetAlertAsUpdated(
+            title = application.getString(R.string.error_cant_create_account),
+            message = desc,
+            type = AlertType.REGULAR_OK_ALERT,
+            shouldCloseAppAfterDone = false
+        )
         setShouldShowDismissProgressAsUpdated()
-        setShouldShowAlertAsUpdated()
+        //setShouldShowAlertAsUpdated()
     }
 
     private fun showStockErrorState() {

--- a/code/account/create-account/src/main/res/layout/upload_photo_fragment.xml
+++ b/code/account/create-account/src/main/res/layout/upload_photo_fragment.xml
@@ -32,7 +32,7 @@
             android:layout_width="@dimen/tv_take_picture_or_choose_from_library_width"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_20dp"
-            android:text="@string/take_a_picture_or_choose_from_library"
+            android:text="@string/click_image_to_take_a_picture_or_choose_from_library"
             android:gravity="center_horizontal"
             android:textSize="@dimen/header_text_size"
             android:textStyle="bold"
@@ -41,23 +41,6 @@
             app:layout_constraintHorizontal_bias="0.662"
             app:layout_constraintStart_toStartOf="@+id/cvTakeAPhoto"
             app:layout_constraintTop_toBottomOf="@+id/cvTakeAPhoto"
-            />
-
-        <Button
-            android:id="@+id/btnChooseFormLibrary"
-            android:layout_width="@dimen/btn_choose_from_library_width"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_20dp"
-            android:background="@drawable/corner_button"
-            android:padding="@dimen/padding_10dp"
-            android:textStyle="bold"
-            android:textSize="@dimen/sub_header_text_size"
-            android:text="@string/choose_from_library"
-            android:gravity="center_horizontal"
-            android:textColor="@color/colorSmokeWhite"
-            app:layout_constraintEnd_toEndOf="@+id/tvTakeAPictureOrChooseFromLibrary"
-            app:layout_constraintStart_toStartOf="@+id/tvTakeAPictureOrChooseFromLibrary"
-            app:layout_constraintTop_toBottomOf="@+id/tvTakeAPictureOrChooseFromLibrary"
             />
 
         <Button
@@ -71,9 +54,9 @@
             android:textStyle="bold"
             android:padding="@dimen/padding_10dp"
             android:layout_marginTop="@dimen/margin_16dp"
-            app:layout_constraintEnd_toEndOf="@+id/btnChooseFormLibrary"
-            app:layout_constraintStart_toStartOf="@+id/btnChooseFormLibrary"
-            app:layout_constraintTop_toBottomOf="@+id/btnChooseFormLibrary"
+            app:layout_constraintEnd_toEndOf="@+id/tvTakeAPictureOrChooseFromLibrary"
+            app:layout_constraintStart_toStartOf="@+id/tvTakeAPictureOrChooseFromLibrary"
+            app:layout_constraintTop_toBottomOf="@+id/tvTakeAPictureOrChooseFromLibrary"
             />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/code/account/sign-up/src/main/java/com/nicholasrutherford/chal/account/sign/up/SignUpFragment.kt
+++ b/code/account/sign-up/src/main/java/com/nicholasrutherford/chal/account/sign/up/SignUpFragment.kt
@@ -69,15 +69,15 @@ class SignUpFragment @Inject constructor(): BaseFragment<SignUpFragmentBinding>(
             }
             binding.ivFacebook.setOnClickListener {
                 viewModel.onFacebookClicked()
-                navigateToUrl(viewModel.viewState.socialMediaUrl)
+                openUrl(viewModel.viewState.socialMediaUrl)
             }
             binding.ivLinkedin.setOnClickListener {
                 viewModel.onLinkedinClicked()
-                navigateToUrl(viewModel.viewState.socialMediaUrl)
+                openUrl(viewModel.viewState.socialMediaUrl)
             }
             binding.ivGram.setOnClickListener {
                 viewModel.onInstagramClicked()
-                navigateToUrl(viewModel.viewState.socialMediaUrl)
+                openUrl(viewModel.viewState.socialMediaUrl)
             }
         }
     }

--- a/code/data/alert/src/main/java/com/nicholasrutherford/chal/data/elert/AlertType.kt
+++ b/code/data/alert/src/main/java/com/nicholasrutherford/chal/data/elert/AlertType.kt
@@ -3,5 +3,6 @@ package com.nicholasrutherford.chal.data.elert
 enum class AlertType {
     REGULAR_OK_ALERT,
     YES_ALERT_WITH_ACTION,
-    YES_NO_ALERT_WITH_ACTION
+    YES_NO_ALERT_WITH_ACTION,
+    CAMERA_OR_GALLERY_ALERT
 }

--- a/code/main/resources/src/main/res/values/strings.xml
+++ b/code/main/resources/src/main/res/values/strings.xml
@@ -101,9 +101,12 @@
     <string name="error_updating_data_title">Error Updating Data</string>
     <string name="error_updating_data_desc">Error updating your progress! Please press OK and try again!</string>
     <string name="first_name">First Name</string>
+    <string name="from_caoture">From Capture</string>
+    <string name="from_gallery">From Gallery</string>
     <string name="header_font_bold_text_title">Header Bold Font</string>
     <string name="hex_black">#000000</string>
     <string name="hex_white">#FFFFFF</string>
+    <string name="how_would_you_like_to_upload_your_image">How would you like to upload your image? Select from capture if you want to take a picture. Or from gallery if you want to select a image from your devices saved photos.</string>
     <string name="high">High</string>
     <string name="issue_creating_your_account">Issue creating your account. Please try again</string>
     <string name="issue_uploading_image_to_server">Issue uploading image to server. Please Try Again</string>
@@ -238,6 +241,7 @@
     <string name="update_progress">Update Progress</string>
     <string name="upload">Upload</string>
     <string name="upload_image">Upload Image</string>
+    <string name="uploading_image">Uploading Image</string>
     <string name="upload_post">Upload Post</string>
     <string name="welcome_to_chal_text">Welcome to chal</string>
     <string name="yes">Yes</string>

--- a/code/main/resources/src/main/res/values/strings.xml
+++ b/code/main/resources/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="chal_menu">Chal Menu</string>
     <string name="chat">Chat</string>
     <string name="cant_login_error">Can\'t find your account. Please try again or create a account!</string>
+    <string name="click_image_to_take_a_picture_or_choose_from_library">Click image to take a picture or choose from your library.</string>
     <string name="click_to_refresh">Click to refresh</string>
     <string name="close">CLOSE</string>
     <string name="creating_your_account">Creating Your Account</string>
@@ -234,7 +235,6 @@
     <string name="success_you_joined_the">Success! You joined the</string>
     <string name="teaser_challenge">Teaser Challenge</string>
     <string name="to_reset_password">To Reset Password.</string>
-    <string name="take_a_picture_or_choose_from_library">Take a photo or choose from your library.</string>
     <string name="try_again">Try Again</string>
     <string name="turn_on_all_features">Turn On All Features</string>
     <string name="username">Username</string>

--- a/code/main/upload-progress/src/main/java/com/nicholasrutherford/chal/main/upload/progress/UploadProgressFragment.kt
+++ b/code/main/upload-progress/src/main/java/com/nicholasrutherford/chal/main/upload/progress/UploadProgressFragment.kt
@@ -52,6 +52,12 @@ class UploadProgressFragment @Inject constructor() : BaseFragment<FragmentUpload
             )
         }
         lifecycleScope.launch {
+            collectIsGalleryResult()
+        }
+        lifecycleScope.launch {
+            collectIsTakePictureResult()
+        }
+        lifecycleScope.launch {
             collectShouldShowAlertResult(
                 this@UploadProgressFragment.id,
                 viewModel.alert,
@@ -127,7 +133,7 @@ class UploadProgressFragment @Inject constructor() : BaseFragment<FragmentUpload
 
             binding.clPostProgress.ivUploadImage.setOnClickListener {
                 viewModel.updateIsPhotoReadyToBeUpdated(true)
-                openGallery()
+        //        openGallery()
             }
 
             binding.tbUploadProgress.tbStock.setOnClickListener {

--- a/code/main/upload-progress/src/main/java/com/nicholasrutherford/chal/main/upload/progress/UploadProgressViewModel.kt
+++ b/code/main/upload-progress/src/main/java/com/nicholasrutherford/chal/main/upload/progress/UploadProgressViewModel.kt
@@ -144,8 +144,6 @@ class UploadProgressViewModel @ViewModelInject constructor(
             type = AlertType.CAMERA_OR_GALLERY_ALERT,
             shouldCloseAppAfterDone = false
         )
-        // TODO prompt to prompt me if i want to take a picture or choose one from my gallery
-//        this.isPhotoReadyToBeUpdated = isPhotoReadyToBeUpdated
     }
 
     fun onDiscardPostClicked() {

--- a/code/main/upload-progress/src/main/java/com/nicholasrutherford/chal/main/upload/progress/UploadProgressViewModel.kt
+++ b/code/main/upload-progress/src/main/java/com/nicholasrutherford/chal/main/upload/progress/UploadProgressViewModel.kt
@@ -139,8 +139,8 @@ class UploadProgressViewModel @ViewModelInject constructor(
     fun updateIsPhotoReadyToBeUpdated(isPhotoReadyToBeUpdated: Boolean) {
         this.isPhotoReadyToBeUpdated = isPhotoReadyToBeUpdated
         setShouldSetAlertAsUpdated(
-            title = "Some text ",
-            message = "Some alert",
+            title = application.getString(R.string.uploading_image),
+            message = application.getString(R.string.how_would_you_like_to_upload_your_image),
             type = AlertType.CAMERA_OR_GALLERY_ALERT,
             shouldCloseAppAfterDone = false
         )

--- a/code/main/upload-progress/src/main/java/com/nicholasrutherford/chal/main/upload/progress/UploadProgressViewModel.kt
+++ b/code/main/upload-progress/src/main/java/com/nicholasrutherford/chal/main/upload/progress/UploadProgressViewModel.kt
@@ -137,8 +137,15 @@ class UploadProgressViewModel @ViewModelInject constructor(
     }
 
     fun updateIsPhotoReadyToBeUpdated(isPhotoReadyToBeUpdated: Boolean) {
-        // TODO prompt to prompt me if i want to take a picture or choose one from my gallery
         this.isPhotoReadyToBeUpdated = isPhotoReadyToBeUpdated
+        setShouldSetAlertAsUpdated(
+            title = "Some text ",
+            message = "Some alert",
+            type = AlertType.CAMERA_OR_GALLERY_ALERT,
+            shouldCloseAppAfterDone = false
+        )
+        // TODO prompt to prompt me if i want to take a picture or choose one from my gallery
+//        this.isPhotoReadyToBeUpdated = isPhotoReadyToBeUpdated
     }
 
     fun onDiscardPostClicked() {

--- a/code/ui/base-fragment/src/main/java/com/nicholasrutherford/chal/ui/base_fragment/BaseFragmentNavigation.kt
+++ b/code/ui/base-fragment/src/main/java/com/nicholasrutherford/chal/ui/base_fragment/BaseFragmentNavigation.kt
@@ -3,10 +3,14 @@ package com.nicholasrutherford.chal.ui.base_fragment
 import android.app.AlertDialog
 import android.content.Intent
 import android.graphics.Color
+import android.net.Uri
+import android.provider.MediaStore
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.findNavController
 import cc.cloudist.acplibrary.ACProgressConstant
 import cc.cloudist.acplibrary.ACProgressFlower
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 const val SEND_EMAIL_TYPE = "message/rfc822"
 
@@ -28,6 +32,24 @@ class BaseFragmentNavigation(private val fragmentActivity: FragmentActivity) {
     }
 
     fun hideFlowerProgress() = flowerLoadingDialog?.dismiss()
+
+    fun startActivityResultForGallerty() {
+        val intent = Intent(Intent.ACTION_PICK)
+        intent.type = GALLERY_TYPE
+
+        fragmentActivity.startActivityForResult(intent, GALLERY_REQUEST_CODE)
+    }
+
+    fun startActivityResultForCamera() {
+        val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        fragmentActivity.startActivityForResult(cameraIntent, CAMERA_CAPTURE_REQUEST)
+    }
+
+    fun startActivityForUrl(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW)
+        intent.data = ((Uri.parse(url)))
+        fragmentActivity.startActivity(intent)
+    }
 
     fun showCreateEmailForBug(reporterName: String, bugTitle: String, bugDesc: String, priorityLevel: String) {
         try {
@@ -105,5 +127,25 @@ class BaseFragmentNavigation(private val fragmentActivity: FragmentActivity) {
         appProgressAlert.setTitle(title)
 
         appProgressAlert.show()
+    }
+
+    fun showCameraOrGalleryAlert(_shouldShowGallery: MutableStateFlow<Boolean>, _shouldShowCapture: MutableStateFlow<Boolean>, title: String?, message: String?) {
+        val alertBuilder = AlertDialog.Builder(fragmentActivity)
+
+        alertBuilder.setMessage(message)
+            .setCancelable(true)
+            .setPositiveButton("From Gallery") { dialog, _ ->
+                dialog.cancel()
+                _shouldShowGallery.value = true
+            }
+            .setNegativeButton("From Capture") { dialog, _ ->
+                dialog.cancel()
+                _shouldShowCapture.value = true
+            }
+
+        val alertBuilderCreate = alertBuilder.create()
+        alertBuilderCreate.setTitle(title)
+
+        alertBuilderCreate.show()
     }
 }

--- a/code/ui/base-fragment/src/main/java/com/nicholasrutherford/chal/ui/base_fragment/BaseFragmentNavigation.kt
+++ b/code/ui/base-fragment/src/main/java/com/nicholasrutherford/chal/ui/base_fragment/BaseFragmentNavigation.kt
@@ -134,11 +134,11 @@ class BaseFragmentNavigation(private val fragmentActivity: FragmentActivity) {
 
         alertBuilder.setMessage(message)
             .setCancelable(true)
-            .setPositiveButton("From Gallery") { dialog, _ ->
+            .setPositiveButton(fragmentActivity.getString(R.string.from_gallery)) { dialog, _ ->
                 dialog.cancel()
                 _shouldShowGallery.value = true
             }
-            .setNegativeButton("From Capture") { dialog, _ ->
+            .setNegativeButton(fragmentActivity.getString(R.string.from_caoture)) { dialog, _ ->
                 dialog.cancel()
                 _shouldShowCapture.value = true
             }


### PR DESCRIPTION
### Trello
https://trello.com/c/JLGSDzin/57-give-the-user-the-ability-to-upload-a-picture-or-take-a-picture-when-uploading-progress-on-said-challenge

### Issues
- If a user goes through the upload progress flow, they only have the ability to get a image from there gallery. 
- If the user clicks on the image view from upload photo on creating profile flow, the user only has the ability to take a picture and not select from gallery. 

### Proposed Changes
- Show a alert for both workflows, and ask the user if they want to either upload a image or pick a image from a gallery. Depending on what they pick, it will go ahead and observe there selection and hence; use there selected image.
- Remove choose from library button, from upload photo. Since its not needed since when you click image view, you have option to do one or the other.  

### TO-DO
- Give a placeholder image for the upload progress flow. 