### PR TITLE
Remove the refresh menu

### DIFF
--- a/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedChallengeHeaderAdapter.kt
+++ b/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedChallengeHeaderAdapter.kt
@@ -67,7 +67,7 @@ class NewsFeedChallengeHeaderAdapter(
 
         fun clickListeners() {
             binding.btnUpdateProgress.setOnClickListener {
-                newsFeedViewModel.onAddProgressTabClicked()
+                newsFeedViewModel.onAddProgressClicked()
             }
         }
 

--- a/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedFragment.kt
+++ b/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedFragment.kt
@@ -49,10 +49,6 @@ class NewsFeedFragment @Inject constructor() : BaseFragment<FragmentNewsFeedBind
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding?.let { binding ->
-            binding.tbMyFeed.inflateMenu(R.menu.navigation_news_feed)
-        }
-
         lifecycleScope.launch {
             collectViewStateResult(viewModel.viewStateUpdated, viewModel._viewStateUpdated)
         }
@@ -125,16 +121,6 @@ class NewsFeedFragment @Inject constructor() : BaseFragment<FragmentNewsFeedBind
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == R.id.navigation_refresh) {
-            viewModel.onRefreshTabClicked()
-            return true
-        } else if (item.itemId == R.id.navigation_add_progress) {
-            return true
-        }
-        return true
-    }
-
     override fun collectAlertAsUpdated() {
         lifecycleScope.launch {
             viewModel.shouldShowAlert.collect { isShouldShowAlert ->
@@ -173,19 +159,11 @@ class NewsFeedFragment @Inject constructor() : BaseFragment<FragmentNewsFeedBind
             binding.clFriendsEmptyState.btnAddFriendEmptyState.setOnClickListener {
                 viewModel.onAddFriendsEmptyStateClicked()
             }
-
-            binding.tbMyFeed.setOnMenuItemClickListener {
-                it?.let { item ->
-                    if (item.itemId == R.id.navigation_refresh) {
-                        viewModel.onRefreshTabClicked()
-                    } else if (item.itemId == R.id.navigation_add_progress) {
-                        viewModel.onAddProgressTabClicked()
-                    }
-                    true
-                } == true
-            }
             binding.clNewsFeedBanner.clBannerType.setOnClickListener {
                 viewModel.onBannerDismissedClicked()
+            }
+            binding.ivUpload.setOnClickListener {
+                viewModel.onAddProgressClicked()
             }
         }
     }

--- a/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedViewModel.kt
+++ b/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedViewModel.kt
@@ -265,7 +265,7 @@ class NewsFeedViewModel @ViewModelInject constructor(
         fetchAllUserActiveChallenges()
     }
 
-    fun onAddProgressTabClicked() {
+    fun onAddProgressClicked() {
         if (isUserEnrolledInAChallenge) {
             navigation.showUploadProgress()
         } else {

--- a/code/main/news-feed/src/main/res/layout/fragment_news_feed.xml
+++ b/code/main/news-feed/src/main/res/layout/fragment_news_feed.xml
@@ -16,8 +16,19 @@
             app:titleTextColor="@color/colorSmokeWhite"
             app:title="@string/news_feed"
             android:gravity="center_horizontal"
-            app:popupTheme="@style/AppTheme"
+            app:popupTheme="@style/AppTheme">
+
+        <ImageView
+            android:id="@+id/ivUpload"
+            android:layout_width="20sp"
+            android:layout_height="20sp"
+            android:layout_marginRight="@dimen/margin_10dp"
+            android:layout_marginEnd="@dimen/margin_10dp"
+            android:src="@drawable/ic_upload_white"
+            android:layout_gravity="right"
             />
+
+        </androidx.appcompat.widget.Toolbar>
 
         <SearchView
             android:id="@+id/svHome"


### PR DESCRIPTION
### Trello
https://trello.com/b/Sv7KlTpZ/android-chal-mobile-development

### Issues
- The refresh menu item on the news feed screen, never really served a huge purpose. If users want a refresh option down the line, we can def make it(but ad of now, we should remove it). 

### Proposed Changes
- Remove the refresh item. 
- Because the refresh item is removed, there's no point of the menu. Remove the menu, and replace it with a upload image.Clicking on said icon, takes you to upload progress screen if your involved in at least one challenge. 

### TO-DO
- Possible refresh functionality? 