### PR TITLE
Add a progress alert mask to the news feed scree

### DIFF
--- a/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedFragment.kt
+++ b/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedFragment.kt
@@ -75,7 +75,7 @@ class NewsFeedFragment @Inject constructor() : BaseFragment<FragmentNewsFeedBind
                     bindListAdapter(newsFeedList)
                     viewModel.waitBeforeWeDismissProgress()
                 } else {
-                    viewModel.setShouldShowDismissProgressAsUpdated()
+                    // add ssomethinm here down the line
                 }
             }
         }

--- a/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedViewModel.kt
+++ b/code/main/news-feed/src/main/java/com/nicholasrutherford/chal/main/news/feed/NewsFeedViewModel.kt
@@ -55,7 +55,6 @@ class NewsFeedViewModel @ViewModelInject constructor(
     val viewState = NewsFeedViewStateImpl()
 
     init {
-        setShouldShowProgressAsUpdated()
         viewModelScope.launch {
             loggedInUsername.collect { loggedInUsername ->
                 username = loggedInUsername
@@ -74,6 +73,8 @@ class NewsFeedViewModel @ViewModelInject constructor(
                 setCurrentBannerType(bannerTypeValue)
             }
         }
+
+        setShouldShowProgressAsUpdated()
 
         fetchLoggedInUsername()
 
@@ -164,7 +165,7 @@ class NewsFeedViewModel @ViewModelInject constructor(
     fun waitBeforeWeDismissProgress() {
         Handler(Looper.getMainLooper()).postDelayed({
             setShouldShowDismissProgressAsUpdated()
-        }, 1500.toLong())
+        }, 1000.toLong())
     }
 
 //    fun updateDayOfAllActiveChallenges(activeChallenges: List<ActiveChallengesListResponse>) {
@@ -257,12 +258,6 @@ class NewsFeedViewModel @ViewModelInject constructor(
 
     fun onAddFriendsEmptyStateClicked() {
         // showPeoplkesList
-    }
-
-    fun onRefreshTabClicked() {
-        fetchUserEnrolledInAChallenge()
-        fetchAllPosts()
-        fetchAllUserActiveChallenges()
     }
 
     fun onAddProgressClicked() {


### PR DESCRIPTION
### Trello
https://trello.com/c/lh6sFZCK/71-add-a-progress-alert-mask-to-the-news-feed-screen

### Issues
- Currently we don't have a progress screen showing when the user loads there news feed list(even there is suppose to be one showing). 
- This is because the flow we were collecting for `postLists` if it was empty, it would cancel out this progress mask. Well, until the flow gets init with values it will always be empty. 

### Proposed Changes
- Remove the else statement from the collect flow, and just hide the progress mask whenever we get a successful response from post list after 1 second. 

### TO-DO
- Should account for a couple of things thats not accounted for here(no internet connection?, possible empty state if there are no posts in general?)