### PR TITLE
nick: Click me on description on profile screen, should take me to edit profile

### DIFF
--- a/code/main/resources/src/main/res/values/strings.xml
+++ b/code/main/resources/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="sample_challenge_title">Sample Challenge</string>
     <string name="can_not_upload_image_to_server">Can Not Upload Image To Server</string>
     <string name="cancel_and_discard_post">Cancel and Discard Post</string>
+    <string name="category_x">Category: %s</string>
     <string name="category_fitness">Fitness</string>
     <string name="category_education">Education</string>
     <string name="category_travel">Education</string>

--- a/code/profile/src/main/java/com/nicholasrutherford/chal/profile/ProfileFragment.kt
+++ b/code/profile/src/main/java/com/nicholasrutherford/chal/profile/ProfileFragment.kt
@@ -91,6 +91,10 @@ class ProfileFragment @Inject constructor(): BaseFragment<FragmentProfileBinding
         binding?.let { binding ->
             binding.tbProfilePost.tbStock.setOnClickListener { viewModel.onToolbarBackClicked() }
             binding.clProfile.tvProfileEdit.setOnClickListener { viewModel.onEditProfileClicked() }
+            binding.clProfile.tvDescription.setOnClickListener {
+                val description = binding.clProfile.tvDescription.text.toString()
+                viewModel.onDescriptionClicked(description = description)
+            }
         }
     }
 

--- a/code/profile/src/main/java/com/nicholasrutherford/chal/profile/ProfileListAdapter.kt
+++ b/code/profile/src/main/java/com/nicholasrutherford/chal/profile/ProfileListAdapter.kt
@@ -46,8 +46,10 @@ class ProfileListAdapter(
             typefaces.setTextViewBodyItalicTypeface(binding.tvChallengeCategory)
             typefaces.setTextViewBodyItalicTypeface(binding.tvChallengeCurrentDay)
 
-            binding.tvChallengeTitle.text = activeChallengesListResponse[position].activeChallenges?.name ?: ""
-            binding.tvChallengeCategory.text = "Category $categoryName"
+            binding.tvChallengeTitle.text = activeChallengesListResponse[position].activeChallenges?.name
+                ?: application.getString(R.string.empty_string)
+
+            binding.tvChallengeCategory.text = application.getString(R.string.category_x, categoryName)
             binding.tvChallengeCurrentDay.text =
                 application.getString(R.string.days_completed, challengeCurrentDay!!.toInt(), daysOfChallenge!!.toInt())
 
@@ -55,12 +57,8 @@ class ProfileListAdapter(
                 .placeholder(R.drawable.circle)
                 .error(R.drawable.circle)
 
-           // Picasso.get().load(challengeTypeImage(position)).into(binding.cvChallengeCategory)
-
             Glide.with(application).load(challengeTypeImage(position)).apply(options)
                 .into(binding.cvChallengeCategory)
-
-            println(challengeTypeImage(position))
 
             binding.ll.setOnClickListener {
                 viewModel.onItemClicked(index = position)

--- a/code/profile/src/main/java/com/nicholasrutherford/chal/profile/ProfileViewModel.kt
+++ b/code/profile/src/main/java/com/nicholasrutherford/chal/profile/ProfileViewModel.kt
@@ -24,6 +24,8 @@ class ProfileViewModel @ViewModelInject constructor(
     private val _allUserActiveChallengesList = MutableStateFlow(listOf<ActiveChallengesListResponse>())
     val allUserActiveChallengesList: StateFlow<List<ActiveChallengesListResponse>> = _allUserActiveChallengesList
 
+    val clickHereToAddADescriptionDescription = application.getString(R.string.click_here_to_add_a_description)
+
     val viewState = ProfileViewStateImpl()
 
     init {
@@ -45,7 +47,7 @@ class ProfileViewModel @ViewModelInject constructor(
         viewState.age = age
 
         if (description.isEmpty()) {
-            viewState.description = application.getString(R.string.click_here_to_add_a_description)
+            viewState.description = clickHereToAddADescriptionDescription
         } else {
             viewState.description = description
         }
@@ -65,6 +67,12 @@ class ProfileViewModel @ViewModelInject constructor(
         val newIndex = index.toString()
 
         navigation.showProfileChallengePosts(newIndex)
+    }
+
+    fun onDescriptionClicked(description: String) {
+        if (description == clickHereToAddADescriptionDescription) {
+            navigation.showEditProfile()
+        }
     }
 
     private fun fetchAllUserActiveChallenges() = fetchFirebaseDatabase.fetchAllUserActiveChallenges(_allUserActiveChallengesList)


### PR DESCRIPTION
### Trello
https://trello.com/c/9hyaAgf5/109-functionality-click-me-on-description-on-profile-screen-should-take-me-to-edit-profile

### Issues
- If I am a user who doesn't have a description for my profile, I should have the ability to click copy to take me to the `EditProfile` fragment to add said copy. 
- Need to refactor the adapter profile screen. 

### Proposed Changes
- When clicking on the copy, and it says `Click me to add a description`, I should be taken to the `EditProfile` fragment to edit my profile description details.
- Refactor adapter profile screen 

### TO-DO
- Some more refactoring of classes. 

### Additional Info
- N/A 

### Screenshots
- N/A 
