### PR TITLE
nick: Create a function, for bulk removal of challenges in the all-active-challenges node

### DIFF
--- a/code/firebase/realtime-database/delete/src/main/java/com/nicholasrutherford/chal/firebase/realtime/database/delete/DeleteFirebaseDatabase.kt
+++ b/code/firebase/realtime-database/delete/src/main/java/com/nicholasrutherford/chal/firebase/realtime/database/delete/DeleteFirebaseDatabase.kt
@@ -12,4 +12,11 @@ interface DeleteFirebaseDatabase {
     // the all-active challenge node in firebase
     // and it gets removed, simply by its index
     fun deleteAChallengeInAllActive(index: String, _status: MutableStateFlow<FirebaseStatus>)
+
+    // this simply removes a challenge by
+    // the all active challenge node in firebase
+    // and it gets removed, by the list of indexes.
+    // it will loop throught he size of the index
+    // and remove it one index at a time
+    fun deleteBulkChallengesInAllActive(listIndexes: List<String>, _status: MutableStateFlow<FirebaseStatus>)
 }

--- a/code/firebase/realtime-database/delete/src/main/java/com/nicholasrutherford/chal/firebase/realtime/database/delete/DeleteFirebaseDatabaseImpl.kt
+++ b/code/firebase/realtime-database/delete/src/main/java/com/nicholasrutherford/chal/firebase/realtime/database/delete/DeleteFirebaseDatabaseImpl.kt
@@ -20,4 +20,22 @@ class DeleteFirebaseDatabaseImpl @Inject constructor() : DeleteFirebaseDatabase 
             _status.value = FirebaseStatus.ON_CANCELED
         }
     }
+
+    override fun deleteBulkChallengesInAllActive(
+        listIndexes: List<String>,
+        _status: MutableStateFlow<FirebaseStatus>
+    ) {
+        var status = FirebaseStatus.NONE
+        listIndexes.forEach { index ->
+            database.getReference("$USERS$ALL_ACTIVE_CHALLENGES$index").removeValue().addOnSuccessListener {
+                status = FirebaseStatus.SUCCESSFUL
+            }.addOnFailureListener {
+                status = FirebaseStatus.FAILURE
+            }.addOnCanceledListener {
+                status = FirebaseStatus.ON_CANCELED
+            }
+        }
+
+        _status.value = status
+    }
 }


### PR DESCRIPTION
### Trello
https://trello.com/c/35GYt27H/115-create-a-function-for-bulk-removal-of-challenges-in-the-all-active-challenges-node

### Issues
- We need to create a function that handles bulk removal of challenges in the `all-active-challenges` node, database reference in firebase. 

### Proposed Changes
- Create said function. This function really just loops over all of the indexes, and then removes then one by one. After that, it sets the status which can be observed if needed. 

### TO-DO
- More firebase delete functionality. 

### Additional Info
- N/A 

### Screenshots
- N/A 

